### PR TITLE
Add Lionsbot fleet adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We encourage you to share your open source adapters with the community by submit
 | [TurtleBot2 Yujin/Kobuki](http://kobuki.yujinrobot.com/about2/) | Full Control | https://github.com/open-rmf/free_fleet |
 | [Ubiquity Robotics](https://www.ubiquityrobotics.com/) | Full Control | https://github.com/open-rmf/free_fleet |
 | [InOrbit](https://www.inorbit.ai/) | Full Control | https://github.com/inorbit-ai/ros_amr_interop |
-| [Lionsbot International](https://www.lionsbot.com/) | Full Control | https://github.com/lionsbot-official/fleet_adapter_lionsbot |
+| [LionsBot](https://www.lionsbot.com/) | Full Control | https://github.com/lionsbot-official/fleet_adapter_lionsbot |
 
 ## Elevator / Lift Adapters
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ We encourage you to share your open source adapters with the community by submit
 | [TurtleBot2 Yujin/Kobuki](http://kobuki.yujinrobot.com/about2/) | Full Control | https://github.com/open-rmf/free_fleet |
 | [Ubiquity Robotics](https://www.ubiquityrobotics.com/) | Full Control | https://github.com/open-rmf/free_fleet |
 | [InOrbit](https://www.inorbit.ai/) | Full Control | https://github.com/inorbit-ai/ros_amr_interop |
+| [Lionsbot International](https://www.lionsbot.com/) | Full Control | https://github.com/lionsbot-official/fleet_adapter_lionsbot |
 
 ## Elevator / Lift Adapters
 


### PR DESCRIPTION
Hi, we're from LionsBot and we've written a a full control fleet adapter to integrate Open-RMF with our robots. Repo can be found at https://github.com/lionsbot-official/fleet_adapter_lionsbot. Thank you!