### PR TITLE
Added Megazo RMF Door Adapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ We encourage you to share your open source adapters with the community by submit
 |-----|----|
 | [Dormakaba](https://www.dormakaba.com/) | https://github.com/open-rmf/door_adapter_dormakaba |
 | [Octa Robotics](https://www.octa8.jp/service/) | https://github.com/octarobotics/lci-rmf-adapter |
+| [Megazo](https://www.linkedin.com/company/megazo/) | https://github.com/KABAM-Robotics/door_adapter_megazo |
 
 ## Workcells
 


### PR DESCRIPTION
## Purpose of Pull Request :bookmark: 
This Pull Request is to add **Megazo Door Adapter**, as developed by **Kabam Robotics**, to the public list for easier search and access among ROS-RMF developers.