### PR TITLE
Add QuikSync fleet + lift + door adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ We encourage you to share your open source adapters with the community by submit
 | [Mobile Industrial Robots: MiR](https://www.mobile-industrial-robots.com/) | Full Control | https://github.com/osrf/fleet_adapter_mir |
 | [Mobile Industrial Robots: MiRFleet](https://www.mobile-industrial-robots.com/) | Full Control | https://github.com/osrf/fleet_adapter_mir |
 | [OTTO Motors](https://ottomotors.com/) | Full Control | https://github.com/open-rmf/fleet_adapter_clearpath |
+| [QuikSync](https://quikbot.ai/) | Full Control | https://github.com/quikbot/open-rmf-adapters-quiksync/tree/main/packages/fleet_adapter_quiksync |
 | [Senserbot](https://www.senserbot.com) | Full Control | https://bitbucket.org/rmf-sb/fleet_adapter_aurora/ |
 | [temi Robots](https://www.robotemi.com/) | Full Control | https://github.com/open-rmf/temi_fleet_adapter_python |
 | [TurtleBot4 Clearpath Robotics](https://clearpathrobotics.com/) | Full Control | https://github.com/open-rmf/fleet_adapter_tb4 |
@@ -32,6 +33,7 @@ We encourage you to share your open source adapters with the community by submit
 |-----|----|
 | [KONE](https://www.kone.com/en/) | https://github.com/sharp-rmf/kone_lift_controller |
 | [Octa Robotics](https://www.octa8.jp/service/) | https://github.com/octarobotics/lci-rmf-adapter |
+| [QuikSync](https://quikbot.ai/) | https://github.com/quikbot/open-rmf-adapters-quiksync/tree/main/packages/lift_adapter_quiksync |
 
 ## Door Adapters
 
@@ -40,6 +42,7 @@ We encourage you to share your open source adapters with the community by submit
 | [Dormakaba](https://www.dormakaba.com/) | https://github.com/open-rmf/door_adapter_dormakaba |
 | [Octa Robotics](https://www.octa8.jp/service/) | https://github.com/octarobotics/lci-rmf-adapter |
 | [Megazo](https://www.linkedin.com/company/megazo/) | https://github.com/KABAM-Robotics/door_adapter_megazo |
+| [QuikSync](https://quikbot.ai/) | https://github.com/quikbot/open-rmf-adapters-quiksync/tree/main/packages/door_adapter_quiksync |
 
 ## Workcells
 


### PR DESCRIPTION
Adds the [QuikSync](https://quikbot.ai/) Open-RMF Adapters to the three relevant tables (Fleet, Lift, Door). The three adapters live in a single repo + share an Auth0 M2M HTTPS + WSS client.

- Repo: https://github.com/quikbot/open-rmf-adapters-quiksync
- License: Apache-2.0
- ROS 2: Jazzy
- Packages:
  - \`fleet_adapter_quiksync\` — Open-RMF \`EasyFullControl\` adapter
  - \`door_adapter_quiksync\` — \`rmf_door_msgs\` bridge
  - \`lift_adapter_quiksync\` — \`rmf_lift_msgs\` bridge with adapter-side defense-in-depth session lock (pattern borrowed from [octarobotics/lci-rmf-adapter](https://github.com/octarobotics/lci-rmf-adapter))

All three packages share \`--dry-run\` smoke modes that exercise auth + HTTP + WSS without the \`rmf_ros2\` stack, useful for CI and operator pre-flight checks. End-to-end smoke runbook is in [\`docs/smoke.md\`](https://github.com/quikbot/open-rmf-adapters-quiksync/blob/main/docs/smoke.md).

Happy to adjust the wording / link targets if anything doesn't fit the table conventions.

---

Some portions of this pull request were generated using Anthropic Claude Code (model: claude-opus-4-7, 1M context).